### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,10 @@ jobs:
             gap-version: "4.11.0"
           - python-version: "3.8"
             gap-version: "4.10.2"
+          - platform: "macos-latest"
+            python-version: "3.6"
+          - platform: "macos-latest"
+            python-version: "3.7"
     runs-on: "${{ matrix.platform }}"
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,17 +13,13 @@ jobs:
       fail-fast: false
       matrix:
         platform: ["ubuntu-latest", "macos-latest"]
-        python-version: ["3.6", "3.7", "3.8"]
+        python-version: ["3.7", "3.8"]
         gap-version: ["4.10.2", "4.11.0"]
         exclude:
-          - python-version: "3.6"
-            gap-version: "4.11.0"
           - python-version: "3.7"
             gap-version: "4.11.0"
           - python-version: "3.8"
             gap-version: "4.10.2"
-          - platform: "macos-latest"
-            python-version: "3.6"
           - platform: "macos-latest"
             python-version: "3.7"
     runs-on: "${{ matrix.platform }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
             gap-version: "4.10.2"
     runs-on: "${{ matrix.platform }}"
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v1
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
         env:
           # Increase this value to reset cache manually
           CACHE_NUMBER: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           path: ~/conda_pkgs_dir
           key: "${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ matrix.python-version }}-${{ matrix.gap-version }}"
-      - uses: "conda-incubator/setup-miniconda@v2"
+      - uses: "conda-incubator/setup-miniconda@v3"
         with:
           auto-update-conda: true
           python-version: "${{ matrix.python-version }}"

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ gappy/*.dll
 .eggs/
 dist/
 
+## Local development virtual env
+.venv
+
 ## setuptools_scm files
 gappy/_version.py
 

--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ gappy/*.dll
 dist/
 
 ## Local development virtual env
-.venv
+.venv*
 
 ## setuptools_scm files
 gappy/_version.py

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@ Changelog
 v0.1.0a4 (unreleased)
 ---------------------
 
+Breaking changes
+^^^^^^^^^^^^^^^^
+
+* Dropped support for Python 3.6; Python 3.7+ is officially supported (3.6 may
+  still work but is not tested).
+
 Enhancements
 ^^^^^^^^^^^^
 

--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ accessed in this way:
 
 .. code-block:: python
 
-    >>> GAPInfo.Version
+    >>> gap.GAPInfo.Version
     "4.dev"
 
 Most basic Python types have direct equivalents in GAP, and can be passed

--- a/gappy/gapobj.pyx
+++ b/gappy/gapobj.pyx
@@ -1310,7 +1310,7 @@ cdef class GapObj:
         >>> from cysignals.alarm import alarm, AlarmInterrupt
         >>> a, b = gap.GL(1000, 3).GeneratorsOfGroup(); g = a * b
         >>> try:
-        ...     alarm(0.5); g ^ (2 ^ 10000)
+        ...     alarm(0.5); g ^ (gap(2) ^ 10000)
         ... except AlarmInterrupt:
         ...     print('interrupted long computation')
         ...

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = gappy-system
 author = E. Madison Bray
-author-email = embray@lri.fr
+author_email = erik.m.bray@gmail.com
 description = Python interface to GAP
 url = https://github.com/embray/gappy
 long_description = file: README.rst, CHANGES.rst

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,6 @@ classifiers =
     License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)
     Operating System :: POSIX :: Linux
     Programming Language :: Cython
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Topic :: Scientific/Engineering :: Mathematics
@@ -24,7 +23,7 @@ classifiers =
 [options]
 # We set packages to find: to automatically find all sub-packages
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.7
 setup_requires = setuptools_scm
 install_requires =
     cysignals


### PR DESCRIPTION
Get a working baseline for the CI before making other changes (new Python versions, new GAP versions, other fixes etc.)

This goes ahead and drops Python 3.6 support in the CI since it was proving a pain to still maintain (it is quite old by now); will probably target 3.8+ or even 3.10+)

@dimpase what version(s) of Python does Sage support by now?